### PR TITLE
feat: css modules local ident match Next.js

### DIFF
--- a/src/css/webpack.ts
+++ b/src/css/webpack.ts
@@ -1,4 +1,5 @@
 import { NextConfig } from 'next'
+import { getCssModuleLocalIdent } from 'next/dist/build/webpack/config/blocks/css/loaders/getCssModuleLocalIdent'
 import { Configuration as WebpackConfig } from 'webpack'
 
 export const configureCss = (
@@ -19,7 +20,7 @@ export const configureCss = (
           {
             loader: 'css-loader',
             options: {
-              modules: { auto: true }
+              modules: { auto: true, getLocalIdent: getCssModuleLocalIdent }
             }
           },
           'postcss-loader'
@@ -34,7 +35,7 @@ export const configureCss = (
       {
         loader: 'css-loader',
         options: {
-          modules: { auto: true }
+          modules: { auto: true, getLocalIdent: getCssModuleLocalIdent}
         }
       },
       'postcss-loader',


### PR DESCRIPTION
At the moment the CSS module support is hashing the selector class `_2O_9A_HFMvA962tGk3ckR0`. This makes it difficult during development to find the selector class we want to edit or fix. This change will bring the naming convention in line with Next.js, `YourComponent_selector__7kEHA`. Which doesn't hash the selector class.

From:

`_2O_9A_HFMvA962tGk3ckR0`

to:

`YourComponent_selector__7kEHA`

I am not sure if importing from `next/dist...` is going to cause issue for other versions of next.js below 12.
