### PR TITLE
fix: handle css loader import option from

### DIFF
--- a/src/css/webpack.ts
+++ b/src/css/webpack.ts
@@ -21,15 +21,20 @@ export const configureCss = (
           {
             loader: 'css-loader',
             options: {
+              importLoaders: 1,
               url: (url: string, resourcePath: string) =>
                 cssFileResolve(
                   url,
                   resourcePath,
                   nextConfig.experimental?.urlImports
                 ),
-              import: (url: string, _: unknown, resourcePath: string) =>
+              import: (
+                url: string | { url: string; media: string },
+                _: string,
+                resourcePath: string
+              ) =>
                 cssFileResolve(
-                  url,
+                  typeof url === 'string' ? url : url.url,
                   resourcePath,
                   nextConfig.experimental?.urlImports
                 ),
@@ -51,15 +56,20 @@ export const configureCss = (
       {
         loader: 'css-loader',
         options: {
+          importLoaders: 3,
           url: (url: string, resourcePath: string) =>
             cssFileResolve(
               url,
               resourcePath,
               nextConfig.experimental?.urlImports
             ),
-          import: (url: string, _: unknown, resourcePath: string) =>
+          import: (
+            url: string | { url: string; media: string },
+            _: string,
+            resourcePath: string
+          ) =>
             cssFileResolve(
-              url,
+              typeof url === 'string' ? url : url.url,
               resourcePath,
               nextConfig.experimental?.urlImports
             ),
@@ -71,6 +81,7 @@ export const configureCss = (
       {
         loader: 'sass-loader',
         options: {
+          sourceMap: true,
           sassOptions: nextConfig.sassOptions,
           additionalData:
             nextConfig.sassOptions?.prependData ||


### PR DESCRIPTION
fixes #19

Apparently the `import` option for `css-loader` gets passed arguments as specified on the [v3 docs](https://webpack-v3.jsx.app/loaders/css-loader/#function) instead of [v5](https://webpack.js.org/loaders/css-loader/#import) (which is the same as v4).

When I tried to use the v5 option structure, the webpack config validation errored with a link that `import` needed to be a boolean or a function, then linked me to [this](https://github.com/webpack-contrib/css-loader#import) which clearly specifies that it should be the v5 option structure, not the v3 option structure.

What I had before is exactly [how nextjs handles this](https://github.com/vercel/next.js/blob/b7725133f867b5e530dd4bb5d1fd8d5d389e3364/packages/next/build/webpack/config/blocks/css/loaders/global.ts#L34), so I'm wondering if I'm missing a webpack config or something.

I'm at loss for how to get the seemingly proper solution, namely to make sure that the v5 option structure is used instead, or even to make it so this config can mirror what nextjs is doing.

This makes the basic fix to handle the case that it is passed an object or a string.

This also includes setting [importLoaders](https://webpack.js.org/loaders/css-loader/#importloaders) to what nextjs sets its loaders to (1 for regular css, and 3 for sass) so the preprocessors can be called for imports. ([Example](https://github.com/vercel/next.js/blob/b7725133f867b5e530dd4bb5d1fd8d5d389e3364/packages/next/build/webpack/config/blocks/css/loaders/global.ts#L29))