### PR TITLE
Support runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   - [Styled JSX](#styled-jsx)
   - [Postcss](#postcss)
   - [Absolute Imports](#absolute-imports)
+  - [Runtime Config](#runtime-config)
   - [Typescript](#typescript)
   - [next.config.js](#nextconfigjs)
     - [ESM](#esm)
@@ -58,6 +59,8 @@
 👉 [Postcss](#postcss)
 
 👉 [Absolute Imports](#absolute-imports)
+
+👉 [Runtime Config](#runtime-config)
 
 👉 [Typescript](#typescript) (already supported out of the box by Storybook)
 
@@ -455,6 +458,40 @@ export default function HomePage() {
 import 'styles/globals.scss'
 
 // ...
+```
+
+### Runtime Config
+
+Next.js allows for [Runtime Configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) which lets you import a handy `getConfig` function to get certain configuration defined in your `next.config.js` file at runtime.
+
+In the context of Storybook with this addon, you can expect Next.js's [Runtime Configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) feature to work just fine.
+
+Note, because Storybook doesn't server render your components, your components will only see what they normally see on the client side (i.e. they won't see `serverRuntimeConfig` but will see `publicRuntimeConfig`).
+
+For example, consider the following Next.js config:
+
+```js
+// next.config.js
+module.exports = {
+  serverRuntimeConfig: {
+    mySecret: 'secret',
+    secondSecret: process.env.SECOND_SECRET // Pass through env variables
+  },
+  publicRuntimeConfig: {
+    staticFolder: '/static'
+  }
+}
+```
+
+Calls to `getConfig` would return the following object when called within Storybook:
+
+```json
+{
+  "serverRuntimeConfig": {},
+  "publicRuntimeConfig": {
+    "staticFolder": "/static"
+  }
+}
 ```
 
 ### Typescript

--- a/examples/nextv10/components/Links.js
+++ b/examples/nextv10/components/Links.js
@@ -30,6 +30,9 @@ export const Links = () => (
       <Link href="/customFonts">Custom Font Example</Link>
     </li>
     <li>
+      <Link href="/runtimeConfiguration">Runtime Configuration Example</Link>
+    </li>
+    <li>
       <Link href="/typescript">Typescript Example</Link>
     </li>
   </ul>

--- a/examples/nextv10/next.config.js
+++ b/examples/nextv10/next.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  serverRuntimeConfig: {
+    mySecret: 'secret'
+  },
+  publicRuntimeConfig: {
+    message: 'notice how serverRuntimeConfig is empty'
+  }
 }

--- a/examples/nextv10/pages/runtimeConfiguration.js
+++ b/examples/nextv10/pages/runtimeConfiguration.js
@@ -1,0 +1,21 @@
+import { Header } from 'components/Header'
+import getConfig from 'next/config'
+import Head from 'next/head'
+
+export default function RuntimeConfiguration() {
+  return (
+    <div>
+      <Head>
+        <title>Runtime Configuration</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Header />
+      <main>
+        <p>Here is the runtime Configuration:</p>
+        <code>
+          <pre>{JSON.stringify(getConfig(), null, 2)}</pre>
+        </code>
+      </main>
+    </div>
+  )
+}

--- a/examples/nextv10/stories/pages/runtimeConfiguration.stories.jsx
+++ b/examples/nextv10/stories/pages/runtimeConfiguration.stories.jsx
@@ -1,0 +1,8 @@
+import RuntimeConfiguration from '../../pages/runtimeConfiguration'
+
+export default {
+  title: 'Pages',
+  component: RuntimeConfiguration
+}
+
+export const RuntimeConfigurationPage = () => <RuntimeConfiguration />

--- a/examples/nextv11_0/components/Links.js
+++ b/examples/nextv11_0/components/Links.js
@@ -30,6 +30,9 @@ export const Links = () => (
       <Link href="/customFonts">Custom Font Example</Link>
     </li>
     <li>
+      <Link href="/runtimeConfiguration">Runtime Configuration Example</Link>
+    </li>
+    <li>
       <Link href="/typescript">Typescript Example</Link>
     </li>
   </ul>

--- a/examples/nextv11_0/next.config.js
+++ b/examples/nextv11_0/next.config.js
@@ -1,5 +1,11 @@
 module.exports = {
   reactStrictMode: true,
+  serverRuntimeConfig: {
+    mySecret: 'secret'
+  },
+  publicRuntimeConfig: {
+    message: 'notice how serverRuntimeConfig is empty'
+  },
   eslint: {
     ignoreDuringBuilds: true
   }

--- a/examples/nextv11_0/pages/runtimeConfiguration.js
+++ b/examples/nextv11_0/pages/runtimeConfiguration.js
@@ -1,0 +1,21 @@
+import { Header } from 'components/Header'
+import getConfig from 'next/config'
+import Head from 'next/head'
+
+export default function RuntimeConfiguration() {
+  return (
+    <div>
+      <Head>
+        <title>Runtime Configuration</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Header />
+      <main>
+        <p>Here is the runtime Configuration:</p>
+        <code>
+          <pre>{JSON.stringify(getConfig(), null, 2)}</pre>
+        </code>
+      </main>
+    </div>
+  )
+}

--- a/examples/nextv11_0/stories/pages/runtimeConfiguration.stories.jsx
+++ b/examples/nextv11_0/stories/pages/runtimeConfiguration.stories.jsx
@@ -1,0 +1,8 @@
+import RuntimeConfiguration from '../../pages/runtimeConfiguration'
+
+export default {
+  title: 'Pages',
+  component: RuntimeConfiguration
+}
+
+export const RuntimeConfigurationPage = () => <RuntimeConfiguration />

--- a/examples/nextv11_1/components/Links.js
+++ b/examples/nextv11_1/components/Links.js
@@ -30,6 +30,9 @@ export const Links = () => (
       <Link href="/customFonts">Custom Font Example</Link>
     </li>
     <li>
+      <Link href="/runtimeConfiguration">Runtime Configuration Example</Link>
+    </li>
+    <li>
       <Link href="/typescript">Typescript Example</Link>
     </li>
   </ul>

--- a/examples/nextv11_1/next.config.js
+++ b/examples/nextv11_1/next.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  serverRuntimeConfig: {
+    mySecret: 'secret'
+  },
+  publicRuntimeConfig: {
+    message: 'notice how serverRuntimeConfig is empty'
+  }
 }

--- a/examples/nextv11_1/pages/runtimeConfiguration.js
+++ b/examples/nextv11_1/pages/runtimeConfiguration.js
@@ -1,0 +1,21 @@
+import { Header } from 'components/Header'
+import getConfig from 'next/config'
+import Head from 'next/head'
+
+export default function RuntimeConfiguration() {
+  return (
+    <div>
+      <Head>
+        <title>Runtime Configuration</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Header />
+      <main>
+        <p>Here is the runtime Configuration:</p>
+        <code>
+          <pre>{JSON.stringify(getConfig(), null, 2)}</pre>
+        </code>
+      </main>
+    </div>
+  )
+}

--- a/examples/nextv11_1/stories/pages/runtimeConfiguration.stories.jsx
+++ b/examples/nextv11_1/stories/pages/runtimeConfiguration.stories.jsx
@@ -1,0 +1,8 @@
+import RuntimeConfiguration from '../../pages/runtimeConfiguration'
+
+export default {
+  title: 'Pages',
+  component: RuntimeConfiguration
+}
+
+export const RuntimeConfigurationPage = () => <RuntimeConfiguration />

--- a/examples/nextv12/components/Links.js
+++ b/examples/nextv12/components/Links.js
@@ -30,6 +30,9 @@ export const Links = () => (
       <Link href="/customFonts">Custom Font Example</Link>
     </li>
     <li>
+      <Link href="/runtimeConfiguration">Runtime Configuration Example</Link>
+    </li>
+    <li>
       <Link href="/typescript">Typescript Example</Link>
     </li>
   </ul>

--- a/examples/nextv12/next.config.js
+++ b/examples/nextv12/next.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  serverRuntimeConfig: {
+    mySecret: 'secret'
+  },
+  publicRuntimeConfig: {
+    message: 'notice how serverRuntimeConfig is empty'
+  }
 }

--- a/examples/nextv12/pages/runtimeConfiguration.js
+++ b/examples/nextv12/pages/runtimeConfiguration.js
@@ -1,0 +1,21 @@
+import { Header } from 'components/Header'
+import getConfig from 'next/config'
+import Head from 'next/head'
+
+export default function RuntimeConfiguration() {
+  return (
+    <div>
+      <Head>
+        <title>Runtime Configuration</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Header />
+      <main>
+        <p>Here is the runtime Configuration:</p>
+        <code>
+          <pre>{JSON.stringify(getConfig(), null, 2)}</pre>
+        </code>
+      </main>
+    </div>
+  )
+}

--- a/examples/nextv12/stories/pages/runtimeConfiguration.stories.jsx
+++ b/examples/nextv12/stories/pages/runtimeConfiguration.stories.jsx
@@ -1,0 +1,8 @@
+import RuntimeConfiguration from '../../pages/runtimeConfiguration'
+
+export default {
+  title: 'Pages',
+  component: RuntimeConfiguration
+}
+
+export const RuntimeConfigurationPage = () => <RuntimeConfiguration />

--- a/examples/nextv9/components/Links.js
+++ b/examples/nextv9/components/Links.js
@@ -27,6 +27,9 @@ export const Links = () => (
       <Link href="/customFonts">Custom Font Example</Link>
     </li>
     <li>
+      <Link href="/runtimeConfiguration">Runtime Configuration Example</Link>
+    </li>
+    <li>
       <Link href="/typescript">Typescript Example</Link>
     </li>
   </ul>

--- a/examples/nextv9/next.config.js
+++ b/examples/nextv9/next.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  serverRuntimeConfig: {
+    mySecret: 'secret'
+  },
+  publicRuntimeConfig: {
+    message: 'notice how serverRuntimeConfig is empty'
+  }
 }

--- a/examples/nextv9/pages/runtimeConfiguration.js
+++ b/examples/nextv9/pages/runtimeConfiguration.js
@@ -1,0 +1,21 @@
+import { Header } from 'components/Header'
+import getConfig from 'next/config'
+import Head from 'next/head'
+
+export default function RuntimeConfiguration() {
+  return (
+    <div>
+      <Head>
+        <title>Runtime Configuration</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Header />
+      <main>
+        <p>Here is the runtime Configuration:</p>
+        <code>
+          <pre>{JSON.stringify(getConfig(), null, 2)}</pre>
+        </code>
+      </main>
+    </div>
+  )
+}

--- a/examples/nextv9/stories/pages/runtimeConfiguration.stories.jsx
+++ b/examples/nextv9/stories/pages/runtimeConfiguration.stories.jsx
@@ -1,0 +1,8 @@
+import RuntimeConfiguration from '../../pages/runtimeConfiguration'
+
+export default {
+  title: 'Pages',
+  component: RuntimeConfiguration
+}
+
+export const RuntimeConfigurationPage = () => <RuntimeConfiguration />

--- a/src/config/preview.ts
+++ b/src/config/preview.ts
@@ -1,0 +1,3 @@
+import { setConfig } from 'next/config'
+
+setConfig(process.env.__NEXT_RUNTIME_CONFIG)

--- a/src/config/webpack.ts
+++ b/src/config/webpack.ts
@@ -1,0 +1,51 @@
+import { Configuration as WebpackConfig } from 'webpack'
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
+import path from 'path'
+import { NextConfig } from 'next'
+import { DefinePlugin } from 'webpack'
+import { addScopedAlias } from '../utils'
+
+export const configureConfig = async (
+  baseConfig: WebpackConfig,
+  nextConfigPath?: string
+): Promise<NextConfig> => {
+  const nextConfig = await resolveNextConfig(baseConfig, nextConfigPath)
+
+  addScopedAlias(baseConfig, 'next/config')
+  setupRuntimeConfig(baseConfig, nextConfig)
+
+  return nextConfig
+}
+
+const resolveNextConfig = async (
+  baseConfig: WebpackConfig,
+  nextConfigPath?: string
+): Promise<NextConfig> => {
+  const nextConfigExport = await import(
+    nextConfigPath ? nextConfigPath : path.resolve('next.config.js')
+  )
+
+  const nextConfig =
+    typeof nextConfigExport === 'function'
+      ? nextConfigExport(PHASE_DEVELOPMENT_SERVER, {
+          defaultConfig: baseConfig
+        })
+      : nextConfigExport
+
+  return nextConfig
+}
+
+const setupRuntimeConfig = (
+  baseConfig: WebpackConfig,
+  nextConfig: NextConfig
+): void =>
+  void baseConfig.plugins?.push(
+    new DefinePlugin({
+      // this mimics what nextjs does client side
+      // https://github.com/vercel/next.js/blob/57702cb2a9a9dba4b552e0007c16449cf36cfb44/packages/next/client/index.tsx#L101
+      'process.env.__NEXT_RUNTIME_CONFIG': JSON.stringify({
+        serverRuntimeConfig: {},
+        publicRuntimeConfig: nextConfig.publicRuntimeConfig
+      })
+    })
+  )

--- a/src/images/next-image-stub.tsx
+++ b/src/images/next-image-stub.tsx
@@ -1,7 +1,10 @@
 import * as _NextImage from 'next/image'
 import { ImageProps } from 'next/image'
+import semver from 'semver'
 
-try {
+// next v9 (doesn't have next/image)
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+if (semver.gt(process.env.__NEXT_VERSION!, '9.0.0')) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const NextImage = require('next/image') as typeof _NextImage
   const OriginalNextImage = NextImage.default
@@ -16,6 +19,4 @@ try {
         <OriginalNextImage {...props} unoptimized />
       )
   })
-} catch {
-  // next v9 (doesn't have next/image)
 }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -2,13 +2,14 @@
 
 import { StorybookConfig } from '@storybook/core-common'
 import { TransformOptions } from '@babel/core'
-import { resolveNextConfig } from './utils'
+import { configureConfig } from './config/webpack'
 import { configureCss } from './css/webpack'
 import { configureAbsoluteImports } from './absoluteImports/webpack'
 import { configureRouting } from './routing/webpack'
 import { configureStyledJsx } from './styledJsx/webpack'
 import { configureStyledJsxTransforms } from './styledJsx/babel'
 import { configureImages } from './images/webpack'
+import { configureRuntimeNextjsVersionResolution } from './utils'
 import { AddonOptions } from './types'
 
 export const config: StorybookConfig['config'] = (entry = []) => [
@@ -29,8 +30,9 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
   options
 ) => {
   const { nextConfigPath } = options as AddonOptions
-  const nextConfig = await resolveNextConfig(baseConfig, nextConfigPath)
+  const nextConfig = await configureConfig(baseConfig, nextConfigPath)
 
+  configureRuntimeNextjsVersionResolution(baseConfig)
   configureAbsoluteImports(baseConfig)
   configureCss(baseConfig, nextConfig)
   configureImages(baseConfig)

--- a/src/preview.tsx
+++ b/src/preview.tsx
@@ -1,3 +1,4 @@
+import './config/preview'
 import { RouterDecorator } from './routing/decorator'
 import { StyledJsxDecorator } from './styledJsx/decorator'
 import './images/next-image-stub'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,23 +1,18 @@
 import path from 'path'
-import { Configuration as WebpackConfig } from 'webpack'
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
-import { NextConfig } from 'next'
+import { Configuration as WebpackConfig, DefinePlugin } from 'webpack'
+
+export const configureRuntimeNextjsVersionResolution = (
+  baseConfig: WebpackConfig
+): void =>
+  void baseConfig.plugins?.push(
+    new DefinePlugin({
+      'process.env.__NEXT_VERSION': JSON.stringify(getNextjsVersion())
+    })
+  )
 
 export const getNextjsVersion = (): string =>
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   require(scopedResolve('next/package.json')).version
-
-export const resolveNextConfig = async (
-  baseConfig: WebpackConfig,
-  nextConfigPath?: string
-): Promise<NextConfig> => {
-  const nextConfigExport = await import(
-    nextConfigPath ? nextConfigPath : path.resolve('next.config.js')
-  )
-  return typeof nextConfigExport === 'function'
-    ? nextConfigExport(PHASE_DEVELOPMENT_SERVER, { defaultConfig: baseConfig })
-    : nextConfigExport
-}
 
 // This is to help the addon in development
 // Without it, webpack resolves packages in its node_modules instead of the example's node_modules
@@ -57,7 +52,7 @@ export const addScopedAlias = (
  * // after main script path truncation
  * scopedResolve('styled-jsx') === '/some/path/node_modules/styled-jsx'
  */
-const scopedResolve = (id: string) => {
+export const scopedResolve = (id: string): string => {
   const scopedModulePath = require.resolve(id, { paths: [path.resolve()] })
   const moduleFolderStrPosition = scopedModulePath.lastIndexOf(id)
   const beginningOfMainScriptPath = moduleFolderStrPosition + id.length


### PR DESCRIPTION
- support next's [Runtime Configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) api
- update docs to reflect this
- create example pages in example projects
- update image stub to read nextjs version from `process.env`