### PR TITLE
fix(jsconfig): allow for non ts projects or jsconfig projects to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^12.4.0",
     "semver": "^7.3.5",
+    "tsconfig-paths": "^4.0.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2"
   },
   "devDependencies": {

--- a/src/imports/webpack.ts
+++ b/src/imports/webpack.ts
@@ -1,16 +1,25 @@
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
+import { loadConfig } from 'tsconfig-paths'
 import { Configuration as WebpackConfig } from 'webpack'
 
 export const configureImports = (baseConfig: WebpackConfig): void => {
-  baseConfig.resolve = baseConfig.resolve ?? {}
+  const configLoadResult = loadConfig()
 
-  const plugin = new TsconfigPathsPlugin({
-    extensions: ['.js', '.jsx', '.ts', '.tsx']
-  })
-
-  if (baseConfig.resolve.plugins) {
-    baseConfig.resolve.plugins.push(plugin)
-  } else {
-    baseConfig.resolve.plugins = [plugin]
+  if (
+    configLoadResult.resultType === 'failed' ||
+    // in development, the call to loadConfig() will load this addon's tsconfig lol
+    configLoadResult.absoluteBaseUrl.endsWith('storybook-addon-next')
+  ) {
+    return
   }
+
+  baseConfig.resolve ??= {}
+  baseConfig.resolve.plugins ??= []
+
+  baseConfig.resolve.plugins.push(
+    new TsconfigPathsPlugin({
+      configFile: configLoadResult.configFileAbsolutePath,
+      extensions: ['.js', '.jsx', '.ts', '.tsx']
+    })
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7810,7 +7810,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3:
+json5@2.x, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
@@ -12295,6 +12295,15 @@ tsconfig-paths@^3.9.0:
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz#1082f5d99fd127b72397eef4809e4dd06d229b64"
+  integrity sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==
+  dependencies:
+    json5 "^2.2.1"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 


### PR DESCRIPTION
don't load the tsconfig plugin if there is no config to load
ensure the plugin doesn't accidentally load the addon's tsconfig in development
ensure jsconfig files can be loaded too

fix #86