### PR TITLE
fix(babel): allow storybook to pick up custom babel config if defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,32 @@ function HelloWorld() {
 export default HelloWorld
 ```
 
+You can use your own babel config too. This is an example of how you can customize styled-jsx.
+
+```json
+// .babelrc or whatever config file you use
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "styled-jsx": {
+          "plugins": ["@styled-jsx/plugin-sass"]
+        }
+      }
+    ]
+  ]
+}
+```
+
+If you use a monorepo, you may need to add the babel config yourself to your storybook project. Just add a babel config to your storybook project with the following contents to get started.
+
+```json
+{
+  "presets": ["next/babel"]
+}
+```
+
 ### Postcss
 
 Next.js lets you [customize postcss config](https://nextjs.org/docs/advanced-features/customizing-postcss-config#default-behavior). Thus this addon will automatically handle your postcss config for you.

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -22,8 +22,9 @@ export const managerEntries = (entry: string[] = []): string[] => [
   require.resolve('./register')
 ]
 
-export const babel = (config: TransformOptions): TransformOptions =>
-  configureStyledJsxTransforms(config)
+export const babel = async (
+  config: TransformOptions
+): Promise<TransformOptions> => await configureStyledJsxTransforms(config)
 
 export const webpackFinal: StorybookConfig['webpackFinal'] = async (
   baseConfig,

--- a/src/styledJsx/babel.ts
+++ b/src/styledJsx/babel.ts
@@ -1,8 +1,25 @@
-import { TransformOptions } from '@babel/core'
+import { TransformOptions, loadPartialConfigAsync } from '@babel/core'
 
-export const configureStyledJsxTransforms = (
+export const configureStyledJsxTransforms = async (
   config: TransformOptions
-): TransformOptions => ({
-  ...config,
-  plugins: [...(config.plugins ?? []), 'styled-jsx/babel']
-})
+): Promise<TransformOptions> =>
+  (await hasCustomBabelFile())
+    ? // the babel loader will pick up the custom
+      // config file
+      config
+    : {
+        ...config,
+        plugins: [...(config.plugins ?? []), 'styled-jsx/babel']
+      }
+
+const hasCustomBabelFile = async () => {
+  const config = await loadPartialConfigAsync({
+    // in order to load babel config, we need to give babel a file
+    // we just choose the project's package.json cuz we know it has
+    // to be present
+    // filename is resolved relative to the root (defaulted to process.cwd())
+    // https://babeljs.io/docs/en/options#filename
+    filename: './package.json'
+  })
+  return config?.babelrc || config?.config
+}


### PR DESCRIPTION
fix #75