### PR TITLE
Update Image Stub for Next v12.2.0

### DIFF
--- a/src/images/next-image-stub.tsx
+++ b/src/images/next-image-stub.tsx
@@ -21,7 +21,10 @@ if (semver.gt(process.env.__NEXT_VERSION!, '9.0.0')) {
   })
 
   // https://github.com/vercel/next.js/issues/36417#issuecomment-1117360509
-  if (semver.gte(process.env.__NEXT_VERSION!, '12.1.5')) {
+  if (
+    semver.gte(process.env.__NEXT_VERSION!, '12.1.5') &&
+    semver.lt(process.env.__NEXT_VERSION!, '12.2.0')
+  ) {
     Object.defineProperty(NextImage, '__esModule', {
       configurable: true,
       value: true


### PR DESCRIPTION
NextJS no longer requires a bit of code added in to patch a bug that existed in Next v12.1.5 and above. As of v12.2.0, this patch is no longer needed, and furthermore causes a `TypeError` to be thrown when attempting to ugprade to Next 12 and running this addon in your Storybook.

Fixes: #95
Related: #72